### PR TITLE
54 support preferred channel option

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,6 @@ To set up the repository, run:
 
 ```sh
 $ ./scripts/bootstrap
-$ ./scripts/build
 ```
 
 This will install all the required dependencies and build the SDK.

--- a/verification.go
+++ b/verification.go
@@ -252,6 +252,16 @@ const (
 	VerificationNewParamsTargetTypeEmailAddress VerificationNewParamsTargetType = "email_address"
 )
 
+type VerificationNewParamsOptionsPreferredChannel string
+
+const (
+	VerificationNewParamsOptionsPreferredChannelSms      VerificationNewParamsOptionsPreferredChannel = "sms"
+	VerificationNewParamsOptionsPreferredChannelRcs      VerificationNewParamsOptionsPreferredChannel = "rcs"
+	VerificationNewParamsOptionsPreferredChannelWhatsapp VerificationNewParamsOptionsPreferredChannel = "whatsapp"
+	VerificationNewParamsOptionsPreferredChannelViber    VerificationNewParamsOptionsPreferredChannel = "viber"
+	VerificationNewParamsOptionsPreferredChannelZalo     VerificationNewParamsOptionsPreferredChannel = "zalo"
+)
+
 func (r VerificationNewParamsTargetType) IsKnown() bool {
 	switch r {
 	case VerificationNewParamsTargetTypePhoneNumber, VerificationNewParamsTargetTypeEmailAddress:
@@ -321,6 +331,8 @@ type VerificationNewParamsOptions struct {
 	TemplateID param.Field[string] `json:"template_id"`
 	// The variables to be replaced in the template.
 	Variables param.Field[map[string]string] `json:"variables"`
+	// preferred_channel
+	PreferredChannel param.Field[VerificationNewParamsOptionsPreferredChannel] `json:"preferred_channel"`
 }
 
 func (r VerificationNewParamsOptions) MarshalJSON() (data []byte, err error) {

--- a/verification_test.go
+++ b/verification_test.go
@@ -49,6 +49,7 @@ func TestVerificationNewWithOptionalParams(t *testing.T) {
 			Variables: prelude.F(map[string]string{
 				"foo": "bar",
 			}),
+			PreferredChannel: prelude.F(prelude.VerificationNewParamsOptionsPreferredChannelWhatsapp),
 		}),
 		Signals: prelude.F(prelude.VerificationNewParamsSignals{
 			AppVersion:     prelude.F("1.2.34"),


### PR DESCRIPTION
Closes https://github.com/prelude-so/go-sdk/issues/54

I'm not a Go expert and this is my first time contributing to OSS with Go. Open to suggestions and improvements.

## Why?

I want to add support for `preferred_channel` option in the verification request.
The option is documented [here](https://docs.prelude.so/verify/v2/api-reference/create-or-retry-a-verification#body-options-preferred-channel).

## How?

From what I could determine, there are no specific tests against options. I've added it anyway and tests are running find locally:

````
/home/pietro/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.2.linux-amd64/bin/go test -c -o /home/pietro/.cache/JetBrains/GoLand2025.1/tmp/GoLand/___TestVerificationNewWithOptionalParams_in_github_com_prelude_so_go_sdk.test github.com/prelude-so/go-sdk #gosetup
/home/pietro/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.2.linux-amd64/bin/go tool test2json -t /home/pietro/.cache/JetBrains/GoLand2025.1/tmp/GoLand/___TestVerificationNewWithOptionalParams_in_github_com_prelude_so_go_sdk.test -test.v=test2json -test.paniconexit0 -test.run ^\QTestVerificationNewWithOptionalParams\E$ #gosetup
=== RUN   TestVerificationNewWithOptionalParams
--- PASS: TestVerificationNewWithOptionalParams (0.01s)
PASS

Process finished with the exit code 0
```

I've also removed the reference to `./scripts/build` since it does not exist.